### PR TITLE
ci: remove SonarCloud integration and config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,27 +108,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/site/jacoco/jacoco.xml
           slug: h00dieB0y/tika-service
-
-  sonar-analysis:
-    name: SonarQube / SonarCloud
-    needs: upload-coverage
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: "21"
-          cache: maven
-
-      - name: Run SonarQube analysis
-        env:
-          SONAR_TOKEN:       ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL:    https://sonarcloud.io
-          SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY }}
-          SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
-        run: |
-          mvn --batch-mode org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
-            -Dsonar.projectKey="$SONAR_PROJECT_KEY"

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,6 @@
     <springdoc.version>2.8.9</springdoc.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <nimbus-jose-jwt.version>9.23</nimbus-jose-jwt.version>
-    <!-- SonarCloud -->
-    <sonar.organization>jarhead-killgrave</sonar.organization>
-    <sonar.host.url>https://sonarcloud.io</sonar.host.url>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This pull request removes the integration with SonarQube/SonarCloud from the project. The most important changes include the removal of the `sonar-analysis` job from the CI workflow and the deletion of SonarCloud-specific properties from the `pom.xml` file.

### Removal of SonarQube/SonarCloud Integration:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL111-L134): Removed the `sonar-analysis` job, which included steps for setting up JDK 21, configuring SonarCloud environment variables, and running the SonarQube analysis.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L36-L38): Deleted SonarCloud-specific properties, such as `sonar.organization` and `sonar.host.url`, from the Maven configuration.